### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.1] - 2026-04-28
+
+### Fixed
+- Apply Jaccard-weight preprocessing to unweighted graphs before
+  column-stochastic rescaling, so lambda rescaling is no longer degenerate
+  on binary kNN inputs. Default `unweighted_to_weighted=True` in `api.py`
+  and `estimator.py` matches the Julia reference's
+  `flag_unweighted_to_weighted` (see `src/pysgtsnepi/utils/graph_weights.py`).
+
+### Added
+- Thin API surface for the auto-lambda and Lambda Lens helpers used by the
+  IEEE VIS 2026 short paper (carried over from main since v0.3.0).
+
+### Notes
+- Julia-aligned default parameters introduced in v0.3.0 (commit 41d521d)
+  remain unchanged. No breaking API changes since v0.3.0.
+
+[0.3.1]: https://github.com/qqgjyx/sgtsnepi/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/qqgjyx/sgtsnepi/releases/tag/v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pysgtsnepi"
-version = "0.3.0"
+version = "0.3.1"
 description = "Pure Python implementation of SG-t-SNE-Π: Swift Neighbor Embedding of Sparse Stochastic Graphs"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Cuts pysgtsnepi v0.3.1. Bumps `pyproject.toml` version and adds `CHANGELOG.md`. No source changes; packages main HEAD as-is so the unweighted_to_weighted Jaccard preprocessing fix (already on main) lands on PyPI.

## Why now

The Lambda Lens IEEE VIS 2026 short paper currently cites `pip install git+https://github.com/qqgjyx/sgtsnepi.git@b1131f8` because no PyPI build contains the fix. v0.3.1 unblocks the reproducibility line in the paper's Supplemental Materials so it can switch back to `pip install pysgtsnepi`.

## Changes

- `pyproject.toml`: `0.3.0` -> `0.3.1`
- `CHANGELOG.md`: new file, Keep-a-Changelog format, seeded with v0.3.1 notes

### v0.3.1 notes

**Fixed**
- Apply Jaccard-weight preprocessing to unweighted graphs before column-stochastic rescaling, so lambda rescaling is no longer degenerate on binary kNN inputs. Default `unweighted_to_weighted=True` in `api.py` and `estimator.py` matches the Julia reference's `flag_unweighted_to_weighted`.

**Added**
- Thin API surface for the auto-lambda and Lambda Lens helpers used by the IEEE VIS 2026 short paper (carried over from main since v0.3.0).

**Notes**
- Julia-aligned default parameters introduced in v0.3.0 (commit 41d521d) remain unchanged. No breaking API changes since v0.3.0.

## Test plan

- [x] `uv run pytest` locally on the bump branch (29/29 passed)
- [x] `uv build` produces `pysgtsnepi-0.3.1-py3-none-any.whl` and `.tar.gz`
- [x] Wheel installs in a clean venv; `pysgtsnepi.__version__` reports `0.3.1`
- [ ] CI green on PR
- [ ] Tag and GH release after merge -> `python-publish.yml` uploads to PyPI