### PR TITLE
chore: switch PyPI publish workflow to OIDC trusted publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,12 +10,14 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pysgtsnepi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - run: uv build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Replaces the long-lived `PYPI_API_TOKEN` secret with PyPI Trusted Publishing (OIDC). Each publish now exchanges a short-lived GitHub-issued ID token for an upload token at the moment of release, scoped to one workflow run.

## Why

The v0.3.1 release run (workflow #25030155424) failed with `403 Forbidden` because the `PYPI_API_TOKEN` secret no longer authenticates (the action's own warning flagged the token as not starting with `pypi-`). Rotating to a new long-lived token would re-create the same exposure surface; OIDC removes the secret entirely and is the PyPI-recommended path since 2023.

## Changes

- `.github/workflows/python-publish.yml`:
  - Add `id-token: write` permission on the deploy job.
  - Bind the job to a new `pypi` GitHub environment (`https://pypi.org/p/pysgtsnepi`) so a tag-pattern restriction can be added later.
  - Drop `with: user / password` from `pypa/gh-action-pypi-publish` so it auto-detects OIDC.
  - Track `pypa/gh-action-pypi-publish@release/v1` instead of a pinned SHA, matching the publisher's own recommendation.

## Pre-merge checklist (manual)

- [ ] Trusted Publisher added on PyPI: https://pypi.org/manage/project/pysgtsnepi/settings/publishing/
      - Owner: `qqgjyx`, Repo: `sgtsnepi`, Workflow: `python-publish.yml`, Environment: `pypi`
- [ ] GitHub environment `pypi` created at https://github.com/qqgjyx/sgtsnepi/settings/environments
      (optional: restrict deployment branches/tags to `v*.*.*`, add required reviewers)

## Post-merge

- Re-trigger the v0.3.1 publish: `gh release delete v0.3.1 --yes --cleanup-tag=false && gh release create v0.3.1 --notes-file ...`, then watch the new workflow run.
- After the first successful publish under OIDC, delete the unused `PYPI_API_TOKEN` repository secret.

## Test plan

- [ ] Workflow YAML parses (no CI on workflow files alone, but lint will run on the PR).
- [ ] After PyPI Trusted Publisher + GitHub environment are configured, re-running the v0.3.1 release succeeds.
- [ ] `pip index versions pysgtsnepi` lists `0.3.1` after re-trigger.